### PR TITLE
Add skill to auto sync definition to make life better

### DIFF
--- a/.claude/skills/sync-proto/README.md
+++ b/.claude/skills/sync-proto/README.md
@@ -1,0 +1,157 @@
+# Proto Type Sync Skill
+
+## Overview
+
+The `sync-proto` skill automates the synchronization of TypeScript types in this repository with the proto definitions maintained in the `rmp-infra` repository. As the public Decision API evolves, proto definitions are updated in rmp-infra, and this skill helps keep the TypeScript client library in sync.
+
+## Why This Exists
+
+**Problem:**
+- Manual comparison between proto files and TypeScript types is tedious and error-prone
+- Easy to miss new fields, removed fields, or type changes
+- No automated way to detect when types are out of sync
+- Developers need to manually track proto changes across repositories
+
+**Solution:**
+This skill automates the comparison process by:
+1. Dynamically locating the rmp-infra repository
+2. Reading the latest proto definitions
+3. Comparing them with current TypeScript types
+4. Updating TypeScript files when differences are found
+5. Running tests and generating documentation
+
+## Usage
+
+```bash
+/sync-proto
+```
+
+The skill will:
+1. Find the rmp-infra repository (searching parent directories)
+2. Read proto definitions from `protocol/api/adcloud/rmp/decision/v1/public/`
+3. Compare with TypeScript types in `src/v1/{endpoint}/types.ts`
+4. Update types if differences are found
+5. Run tests (`yarn test`)
+6. Generate documentation (`yarn docs`)
+7. Show a summary of changes
+
+## How It Works
+
+### Repository Discovery
+
+The skill dynamically searches for the rmp-infra repository by looking in parent directories (up to 5 levels up from the current directory). This approach:
+- Works across different developer machine configurations
+- Doesn't require hardcoded paths
+- Assumes rmp-infra and decision-api-client-js are sibling directories (or in nearby parent directories)
+- Fails gracefully with a clear error message if rmp-infra is not found
+
+### Proto Files
+
+The skill reads three key proto files:
+1. `service.proto` - Service definitions (RPC endpoints)
+2. `messages.proto` - Request/response message definitions
+3. `decision.proto` - Shared entity definitions
+
+### Endpoints Checked
+
+The skill checks synchronization for three endpoints:
+1. **product-auction** - `DecideAdProducts` (product recommendations)
+2. **brand-auction** - `DecideAdBrands` (brand ads)
+3. **display-auction** - `DecideAdDisplay` (display ads)
+
+For each endpoint, it compares:
+- Request types (proto → TypeScript)
+- Response types (proto → TypeScript)
+- Field mappings in utils (snake_case → camelCase)
+
+### Field Mapping
+
+Proto uses `snake_case` for field names, while TypeScript uses `camelCase`:
+- Proto: `request_id` → TypeScript: `requestId`
+- Proto: `num_ads` → TypeScript: `numAds`
+- Proto: `track_id` → TypeScript: `trackId`
+
+The skill maintains these mappings in `utils.ts` files.
+
+## Architecture
+
+```
+.claude/skills/sync-proto/
+├── SKILL.md     # Skill definition with step-by-step instructions for Claude
+└── README.md    # This file - developer documentation
+```
+
+The skill is intentionally simple:
+- No complex scripts or parsing logic
+- Claude reads proto files directly using Read tool
+- Claude compares manually with TypeScript types
+- Claude updates files using Edit tool
+- Straightforward workflow: read → compare → update → test → docs
+
+## Extending the Skill
+
+### Adding New Endpoints
+
+To add a new endpoint to the sync skill:
+
+1. Add the endpoint to the "Endpoints to Check" section in `SKILL.md`:
+   ```markdown
+   4. **new-endpoint** (`ServiceName`)
+      - Types: `src/v1/new-endpoint/types.ts`
+      - Utils: `src/v1/new-endpoint/utils.ts`
+      - Proto: `RequestMessageName`, `ResponseMessageName`
+   ```
+
+2. Update Step 3 (Compare with Current Types) to include the new endpoint
+
+3. Ensure the new endpoint follows the same structure:
+   - `types.ts` - Type definitions (Params, HttpRequestBody, HttpResponseBody, Data)
+   - `utils.ts` - Conversion utilities (toHttpRequestBody, fromHttpResponseBody)
+
+### Adding New Field Mappings
+
+When new proto fields are added:
+
+1. The skill will detect them automatically in Step 3 (Compare)
+2. Add the snake_case → camelCase mapping to the "Field Mapping Reference" section in `SKILL.md`
+3. The skill will update both types.ts and utils.ts accordingly
+
+### Troubleshooting
+
+**rmp-infra repository not found:**
+- Ensure rmp-infra is cloned in a parent directory of decision-api-client-js
+- The skill searches up to 5 levels up from the current directory
+- Typical setup: `/path/to/projects/rmp-infra` and `/path/to/projects/decision-api-client-js`
+
+**Tests fail after sync:**
+- Check if proto introduced breaking changes
+- Review the diff (`git diff`) to see what was updated
+- Update test fixtures if needed
+- Consult the proto change commit message for migration guidance
+
+**Types don't match proto:**
+- Ensure you're reading the latest proto files (check git status in rmp-infra)
+- Verify proto field types match TypeScript type mappings
+- Check if there are deprecated fields that should be removed
+
+## Contributing
+
+When updating this skill:
+
+1. Keep the skill simple - avoid adding complex parsing or scripting
+2. Follow the existing pattern of step-by-step instructions
+3. Test the skill with both in-sync and out-of-sync scenarios
+4. Update this README with any new patterns or troubleshooting tips
+5. Document any new field mappings in SKILL.md
+
+## Dependencies
+
+- **rmp-infra repository** - Source of proto definitions (must be accessible in parent directories)
+- **yarn** - For running tests and generating documentation
+- **Claude's built-in tools** - Read, Edit, Bash (no additional scripts needed)
+
+## See Also
+
+- [RMP Decision API Reference](https://moloco-rmp.readme.io/reference)
+- [decision-api-client-js Documentation](https://moloco-rmp.github.io/decision-api-client-js)
+- Proto definitions in rmp-infra: `protocol/api/adcloud/rmp/decision/v1/public/`

--- a/.claude/skills/sync-proto/SKILL.md
+++ b/.claude/skills/sync-proto/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: sync-proto
+description: Sync TypeScript types with rmp-infra proto definitions
+version: 1.0.0
+requires:
+  - Access to rmp-infra repository (searched dynamically)
+  - yarn
+---
+
+# Proto Type Sync Skill
+
+Sync TypeScript types with the latest proto definitions from rmp-infra.
+
+## Syntax
+
+```
+/sync-proto
+```
+
+## Instructions for Claude
+
+**IMPORTANT:** Execute each step as a SEPARATE tool call.
+
+### Step 0: Locate rmp-infra Repository
+
+Dynamically find the rmp-infra repository by searching parent directories:
+
+```bash
+# Start from current directory and search upward
+current_dir="$PWD"
+rmp_infra_path=""
+
+# Search up to 5 levels up from current directory
+for i in {1..5}; do
+  parent_dir=$(cd "$current_dir" && cd .. && pwd)
+
+  # Check if rmp-infra exists in parent directory
+  if [ -d "$parent_dir/rmp-infra" ]; then
+    rmp_infra_path="$parent_dir/rmp-infra"
+    break
+  fi
+
+  # Move to parent directory for next iteration
+  current_dir="$parent_dir"
+
+  # Stop if we've reached root
+  if [ "$current_dir" = "/" ]; then
+    break
+  fi
+done
+
+# Check if rmp-infra was found
+if [ -z "$rmp_infra_path" ]; then
+  echo "ERROR: rmp-infra repository not found in parent directories"
+  echo "Please ensure rmp-infra is cloned in a parent directory of decision-api-client-js"
+  exit 1
+fi
+
+# Verify it's a git repository
+if [ ! -d "$rmp_infra_path/.git" ]; then
+  echo "ERROR: Found rmp-infra directory but it's not a git repository: $rmp_infra_path"
+  exit 1
+fi
+
+echo "Found rmp-infra repository at: $rmp_infra_path"
+```
+
+### Step 1: Check Proto Definitions
+
+Read the latest proto commit info:
+```bash
+cd "$rmp_infra_path"
+git log -1 --oneline protocol/api/adcloud/rmp/decision/v1/public/
+```
+
+### Step 2: Read Proto Files
+
+Read the key proto files to understand types. Use the `$rmp_infra_path` variable found in Step 0:
+
+- Read: `$rmp_infra_path/protocol/api/adcloud/rmp/decision/v1/public/api/service.proto`
+- Read: `$rmp_infra_path/protocol/api/adcloud/rmp/decision/v1/public/messages/messages.proto`
+- Read: `$rmp_infra_path/protocol/api/adcloud/rmp/decision/v1/entities/decision.proto`
+
+### Step 3: Compare with Current Types
+
+For each endpoint (productAuction, brandAuction, displayAuction):
+- Read current types.ts file
+- Compare proto message definitions with TypeScript types
+- Identify: new fields, removed fields, type changes, deprecated fields
+
+### Step 4: Update TypeScript Types
+
+For any differences found:
+- Edit types.ts files to add/update/remove fields
+- Edit utils.ts files to handle new field mappings
+- Update external.ts for shared types
+
+### Step 5: Run Tests
+
+```bash
+yarn test
+```
+
+If tests fail, fix the issues and re-run.
+
+### Step 6: Generate Documentation
+
+```bash
+yarn docs
+```
+
+### Step 7: Review Changes
+
+```bash
+git status
+git diff
+```
+
+Show summary of what was changed.
+
+## Endpoints to Check
+
+1. **product-auction** (`DecideAdProducts`)
+   - Types: `src/v1/product-auction/types.ts`
+   - Utils: `src/v1/product-auction/utils.ts`
+   - Proto: `DecisionProductsRequest`, `DecisionProductsResponse`
+
+2. **brand-auction** (`DecideAdBrands`)
+   - Types: `src/v1/brand-auction/types.ts`
+   - Utils: `src/v1/brand-auction/utils.ts`
+   - Proto: `DecisionBrandsRequest`, `DecisionBrandsResponse`
+
+3. **display-auction** (`DecideAdDisplay`)
+   - Types: `src/v1/display-auction/types.ts`
+   - Utils: `src/v1/display-auction/utils.ts`
+   - Proto: `DecisionDisplayRequest`, `DecisionDisplayResponse`
+
+## Field Mapping Reference
+
+Proto field names (snake_case) → TypeScript (camelCase):
+- `request_id` → `requestId`
+- `channel_type` → `channelType`
+- `num_ads` → `numAds`
+- `track_id` → `trackId`
+- `user_id` → `userId`
+- `session_id` → `sessionId`
+- `custom_id` → `customId`
+- `inventory_id` → `inventoryId`
+- `item_id` → `itemId`
+- `item_group_id` → `itemGroupId`
+- `search_query` → `searchQuery`
+- `search_metadata` → `searchMetadata`
+- `custom_item_pool` → `customItemPool`
+- `page_id` → `pageId`
+- `deduplication_setting` → `deduplicationSetting`
+- `per_request` → `perRequest`
+- `os_version` → `osVersion`
+- `advertising_id` → `advertisingId`
+- `unique_device_id` → `uniqueDeviceId`
+- `persistent_id` → `persistentId`
+- `shipping_charge` → `shippingCharge`
+- `amount_micro` → `amountMicro`
+- `price_amount` → `priceAmount`
+- `quality_score` → `qualityScore`
+- `decided_items` → `decidedItems`
+- `auction_result` → `auctionResult`
+- `ad_account_id` → `adAccountId`
+- `campaign_id` → `campaignId`
+- `win_price` → `winPrice`
+- `imp_trackers` → `impTrackers`
+- `click_trackers` → `clickTrackers`
+- `track_id` → `trackId`
+
+## Notes
+
+- Always preserve optional field markers (`?`) when updating types
+- Maintain consistent formatting with existing code style
+- Update both request and response types when proto changes
+- Keep HttpRequestBody and HttpResponseBody in sync with their camelCase counterparts
+- Run tests after each update to ensure no breaking changes

--- a/README.md
+++ b/README.md
@@ -114,4 +114,22 @@ client.auction({ ... })
 - [Full Library Reference](https://moloco-rmp.github.io/decision-api-client-js)
 - [RMP Decision API Reference](https://moloco-rmp.readme.io/reference)
 
+## Development
+
+### Syncing with Proto Definitions
+
+This library's TypeScript types are kept in sync with proto definitions in the `rmp-infra` repository. To check if types are synchronized and update them if needed:
+
+```
+/sync-proto
+```
+
+The skill will automatically:
+- Locate the rmp-infra repository
+- Compare proto definitions with TypeScript types
+- Update types if differences are found
+- Run tests and generate documentation
+
+See [.claude/skills/sync-proto/README.md](.claude/skills/sync-proto/README.md) for details.
+
 © Moloco, Inc. 2022 All rights reserved. Released under Apache 2.0 License


### PR DESCRIPTION
This pull request introduces comprehensive documentation and developer tooling for keeping the TypeScript types in sync with proto definitions from the `rmp-infra` repository. It adds a new "sync-proto" skill, complete with detailed instructions for both developers and Claude, and updates the main `README.md` to guide contributors on how to use the new workflow.

The most important changes are:

**Developer Workflow and Documentation:**

* Added `.claude/skills/sync-proto/README.md` with a detailed overview, architecture, usage instructions, troubleshooting, and extension guidance for the new proto sync skill.
* Updated the main `README.md` with a new "Development" section describing how to sync TypeScript types with proto definitions using the `/sync-proto` command, and referenced the new documentation.

**Automated Sync Skill Definition:**

* Added `.claude/skills/sync-proto/SKILL.md` with step-by-step instructions for Claude to automate the process of locating the `rmp-infra` repo, comparing proto files with TypeScript types, updating files, running tests, and generating documentation. Includes field mapping references and endpoint coverage.